### PR TITLE
fix: release directory in gh actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PROJECT_NAME: personal-website
-  BUILD_DIR: dist
+  BUILD_DIR: dist/
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
- Release action was uploading the folder `dist` instead of all files INSIDE `dist/`