### PR TITLE
fix: release extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,10 +73,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: last-release-artifact
-          path: /tmp/artifact
+          path: ./
 
       - name: Extract release artifact
-        run: mkdir ./dist && tar -xzvf /tmp/artifact/dist.tar.gz -C ./dist
+        run: tar -xzvf dist.tar.gz
 
       - name: Deploy
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
Compressed file has the `dist` folder, and I was uncompressing it by putting it on a `dist` folder, so the actual path was: `dist/dist/*`. 
This PR fixes that, so we can deploy files inside `dist` folder and not the folder itself.