### PR TITLE
fix(ci): remove --frozen-lockfile to support Dependabot PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -20,7 +20,7 @@ jobs:
           bun-version-file: ".bun-version"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Lint commits
         run: bunx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,7 +18,7 @@ jobs:
           bun-version-file: ".bun-version"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Build
         run: bun run build

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,7 +21,7 @@ jobs:
           bun-version-file: ".bun-version"
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Lint
         run: bun run lint


### PR DESCRIPTION
## Description

Removes `--frozen-lockfile` flag from CI workflows to allow Dependabot PRs to pass. When Dependabot updates `package.json`, the lockfile needs to be regenerated, which fails with `--frozen-lockfile`.

Affected workflows:
- `verify.yml`
- `commitlint.yml`
- `lighthouse.yml`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

## Related Issues

<!-- Link any related issues: Fixes #123 -->