### PR TITLE
chore(release): skip success comments on bot-created issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,4 @@
 
 ## Related Issues
 
-<!-- Link any related issues: Fixes #123 -->
+<!-- Link any related issues -->

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,11 +3,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/github",
-      {
-        "successCommentCondition": "<% return issue.user.type !== 'Bot'; %>"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,11 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successCommentCondition": "<% return issue.user.type !== 'Bot'; %>"
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## Description

Configures semantic-release to skip posting success comments on issues/PRs created by bots (e.g., Dependabot).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

## Related Issues

<!-- Link any related issues: Fixes #123 -->