### PR TITLE
chore(release): only post success comments on PRs

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,11 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/github"
+    [
+      "@semantic-release/github",
+      {
+        "successCommentCondition": "<% return issue.pull_request; %>"
+      }
+    ]
   ]
 }


### PR DESCRIPTION
## Description

Configures semantic-release to only post success comments on pull requests, skipping issues.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

## Related Issues

<!-- Link any related issues -->