### PR TITLE
feat(dev): add ViewportIndicator for Tailwind breakpoints and DPR

### DIFF
--- a/src/components/ViewportIndicator.astro
+++ b/src/components/ViewportIndicator.astro
@@ -1,0 +1,31 @@
+---
+/**
+ * ViewportIndicator - Development-only component showing current Tailwind breakpoint and DPR.
+ *
+ * Displays a fixed badge in the bottom-left corner showing the active
+ * responsive breakpoint (xs, sm, md, lg, xl, 2xl) and device pixel ratio.
+ *
+ * @example
+ * ```astro
+ * {import.meta.env.DEV && <ViewportIndicator />}
+ * ```
+ */
+---
+
+<div
+	class="fixed bottom-1 left-1 z-9999 flex place-content-center rounded-full bg-violet-600 p-3 font-mono text-xs text-violet-50"
+	aria-hidden="true"
+>
+	<span class="sm:hidden">xs</span>
+	<span class="hidden sm:block md:hidden">sm</span>
+	<span class="hidden md:block lg:hidden">md</span>
+	<span class="hidden lg:block xl:hidden">lg</span>
+	<span class="hidden xl:block 2xl:hidden">xl</span>
+	<span class="hidden 2xl:block">2xl</span>
+	<span id="dpr-indicator" class="before:mx-1 before:content-['•']"></span>
+</div>
+
+<script is:inline>
+	const dpr = window.devicePixelRatio;
+	document.getElementById("dpr-indicator")?.append(`${dpr}x`);
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import { ClientRouter } from "astro:transitions";
 import ThemeScript from "@/components/ThemeScript.astro";
+import ViewportIndicator from "@/components/ViewportIndicator.astro";
 
 import "../styles/global.css";
 ---
@@ -70,5 +71,6 @@ import "../styles/global.css";
 		class="bg-background text-foreground m-0 bg-[url('/patterns/dots.svg')] bg-[length:24px_auto] bg-repeat py-6"
 	>
 		<slot />
+		{import.meta.env.DEV && <ViewportIndicator />}
 	</body>
 </html>


### PR DESCRIPTION
## Description

Adds a development-only ViewportIndicator component that displays:
- Current Tailwind breakpoint (xs, sm, md, lg, xl, 2xl)
- Device pixel ratio (e.g., 2x)

The indicator appears as a fixed badge in the bottom-left corner and is only rendered in development mode.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

## Related Issues

<!-- Link any related issues -->