### PR TITLE
chore(release): use conventionalcommits preset

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,18 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     [
       "@semantic-release/github",
       {


### PR DESCRIPTION
## Description

Configures semantic-release to use the `conventionalcommits` preset for commit-analyzer and release-notes-generator plugins.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

## Related Issues

<!-- Link any related issues -->