### PR TITLE
refactor(imports): use path aliases instead of relative imports

### DIFF
--- a/src/components/HomePage.astro
+++ b/src/components/HomePage.astro
@@ -3,12 +3,12 @@ import type { Post } from "@/types/post";
 import { socials } from "@/data/socials";
 import { technologies } from "@/data/technologies";
 import { testimonials } from "@/data/testimonials";
-import Container from "./Container.astro";
-import HeroSection from "../sections/HeroSection.astro";
-import StackSection from "../sections/StackSection.astro";
-import LatestPostsSection from "../sections/LatestPostsSection.astro";
-import TestimonialsSection from "../sections/TestimonialsSection.astro";
-import ContactSection from "../sections/ContactSection.astro";
+import Container from "@/components/Container.astro";
+import HeroSection from "@/sections/HeroSection.astro";
+import StackSection from "@/sections/StackSection.astro";
+import LatestPostsSection from "@/sections/LatestPostsSection.astro";
+import TestimonialsSection from "@/sections/TestimonialsSection.astro";
+import ContactSection from "@/sections/ContactSection.astro";
 
 const posts: Post[] = [];
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import HomePage from "../components/HomePage.astro";
-import Layout from "../layouts/Layout.astro";
+import HomePage from "@/components/HomePage.astro";
+import Layout from "@/layouts/Layout.astro";
 
 // Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
 // Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.

--- a/src/types/technology.ts
+++ b/src/types/technology.ts
@@ -1,4 +1,4 @@
-import type { ColorMode, ThemedIcon } from "./icon";
+import type { ColorMode, ThemedIcon } from "@/types/icon";
 
 export type TechnologyCategory = "frameworks" | "languages" | "tools";
 


### PR DESCRIPTION
## Description

Replace relative imports (`../`, `./`) with path aliases (`@/`) for cross-directory imports to improve code consistency and maintainability.

## Type of Change

- [x] Refactor

## Changes

- `src/pages/index.astro` - Updated imports for HomePage and Layout
- `src/components/HomePage.astro` - Updated imports for Container and section components
- `src/types/technology.ts` - Updated import for icon types

Note: Relative imports within feature modules (e.g., `src/lib/theme/`) are kept as-is since they reference files in the same directory.

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed