### PR TITLE
feat(seo): add structured data schemas and improve meta tags

### DIFF
--- a/src/components/TechItem.astro
+++ b/src/components/TechItem.astro
@@ -31,8 +31,7 @@ const isAutoColor = !isThemedIcon && colorMode === "auto";
 				<>
 					<img
 						src={lightIcon}
-						alt=""
-						aria-hidden="true"
+						alt={`${name} logo`}
 						class="tech-icon tech-icon-light size-12 object-contain"
 						width="48"
 						height="48"
@@ -41,8 +40,7 @@ const isAutoColor = !isThemedIcon && colorMode === "auto";
 					/>
 					<img
 						src={darkIcon}
-						alt=""
-						aria-hidden="true"
+						alt={`${name} logo`}
 						class="tech-icon tech-icon-dark size-12 object-contain"
 						width="48"
 						height="48"
@@ -53,8 +51,7 @@ const isAutoColor = !isThemedIcon && colorMode === "auto";
 			) : (
 				<img
 					src={iconSrc}
-					alt=""
-					aria-hidden="true"
+					alt={`${name} logo`}
 					class:list={[
 						"size-12 object-contain",
 						{ "tech-icon-auto": isAutoColor },

--- a/src/components/seo/BreadcrumbJsonLd.astro
+++ b/src/components/seo/BreadcrumbJsonLd.astro
@@ -1,0 +1,32 @@
+---
+/**
+ * BreadcrumbJsonLd - Renders JSON-LD BreadcrumbList schema for SEO.
+ *
+ * Generates BreadcrumbList schema to help search engines understand
+ * the page hierarchy and potentially show breadcrumbs in search results.
+ */
+
+interface BreadcrumbItem {
+	name: string;
+	url: string;
+}
+
+interface Props {
+	items: BreadcrumbItem[];
+}
+
+const { items } = Astro.props;
+
+const jsonLd = {
+	"@context": "https://schema.org",
+	"@type": "BreadcrumbList",
+	itemListElement: items.map((item, index) => ({
+		"@type": "ListItem",
+		position: index + 1,
+		name: item.name,
+		item: item.url,
+	})),
+};
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />

--- a/src/components/seo/HomePageJsonLd.astro
+++ b/src/components/seo/HomePageJsonLd.astro
@@ -1,0 +1,88 @@
+---
+/**
+ * HomePageJsonLd - Combined JSON-LD schema for the homepage.
+ *
+ * Uses @graph to combine multiple schema types:
+ * - WebSite: Site-level information
+ * - ProfilePage: Google's ProfilePage schema for personal sites
+ * - Person: Detailed person information
+ *
+ * @see https://developers.google.com/search/docs/appearance/structured-data/profile-page
+ */
+import {
+	siteOwner,
+	siteName,
+	socialUrls,
+	employer,
+	profileImage,
+} from "@/data/seo";
+
+interface Props {
+	siteUrl: string;
+	jobTitle: string;
+	description: string;
+}
+
+const { siteUrl, jobTitle, description } = Astro.props;
+
+// Person entity (referenced by ProfilePage and WebSite)
+const personEntity = {
+	"@type": "Person",
+	"@id": `${siteUrl}/#person`,
+	name: siteOwner.name,
+	url: siteUrl,
+	image: `${siteUrl}${profileImage}`,
+	email: `mailto:${siteOwner.email}`,
+	jobTitle,
+	description,
+	sameAs: socialUrls,
+	knowsLanguage: [...siteOwner.languages],
+	worksFor: {
+		"@type": "Organization",
+		name: employer.name,
+		url: employer.url,
+	},
+	address: {
+		"@type": "PostalAddress",
+		addressLocality: siteOwner.address.locality,
+		addressCountry: siteOwner.address.country,
+	},
+};
+
+// WebSite entity
+const websiteEntity = {
+	"@type": "WebSite",
+	"@id": `${siteUrl}/#website`,
+	name: siteName,
+	url: siteUrl,
+	description,
+	inLanguage: [...siteOwner.languages],
+	author: {
+		"@id": `${siteUrl}/#person`,
+	},
+};
+
+// ProfilePage entity (Google's schema for personal profile pages)
+const profilePageEntity = {
+	"@type": "ProfilePage",
+	"@id": `${siteUrl}/#profilepage`,
+	url: siteUrl,
+	name: `${siteOwner.name} - ${jobTitle}`,
+	description,
+	isPartOf: {
+		"@id": `${siteUrl}/#website`,
+	},
+	mainEntity: {
+		"@id": `${siteUrl}/#person`,
+	},
+	dateCreated: "2024-01-01",
+	dateModified: new Date().toISOString().split("T")[0],
+};
+
+const jsonLd = {
+	"@context": "https://schema.org",
+	"@graph": [websiteEntity, profilePageEntity, personEntity],
+};
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />

--- a/src/components/seo/OpenGraphMeta.astro
+++ b/src/components/seo/OpenGraphMeta.astro
@@ -8,6 +8,7 @@
  * @see https://ogp.me/
  */
 import { ogLocales, type Locale } from "@/i18n";
+import { siteName } from "@/data/seo";
 
 export interface ArticleMeta {
 	publishedTime: string;
@@ -53,6 +54,7 @@ const {
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 <meta property="og:url" content={url} />
+<meta property="og:site_name" content={siteName} />
 <meta property="og:type" content={type} />
 <meta property="og:locale" content={ogLocales[locale]} />
 <meta property="og:locale:alternate" content={ogLocales[alternateLocale]} />

--- a/src/components/seo/PersonJsonLd.astro
+++ b/src/components/seo/PersonJsonLd.astro
@@ -3,10 +3,10 @@
  * PersonJsonLd - Renders JSON-LD Person schema for SEO.
  *
  * Generates Person schema with site owner information,
- * job title, social links, and location data.
+ * job title, social links, location data, and employment info.
  * Used on homepage and about pages.
  */
-import { siteOwner, socialUrls } from "@/data/seo";
+import { siteOwner, socialUrls, employer, profileImage } from "@/data/seo";
 
 interface Props {
 	siteUrl: string;
@@ -21,10 +21,17 @@ const jsonLd = {
 	"@type": "Person",
 	name: siteOwner.name,
 	url: siteUrl,
+	image: `${siteUrl}${profileImage}`,
+	email: `mailto:${siteOwner.email}`,
 	jobTitle,
 	description,
 	sameAs: socialUrls,
 	knowsLanguage: siteOwner.languages,
+	worksFor: {
+		"@type": "Organization",
+		name: employer.name,
+		url: employer.url,
+	},
 	address: {
 		"@type": "PostalAddress",
 		addressLocality: siteOwner.address.locality,

--- a/src/components/seo/WebSiteJsonLd.astro
+++ b/src/components/seo/WebSiteJsonLd.astro
@@ -1,0 +1,32 @@
+---
+/**
+ * WebSiteJsonLd - Renders JSON-LD WebSite schema for SEO.
+ *
+ * Generates WebSite schema to help search engines understand
+ * the site structure and potentially enable sitelinks.
+ * Used on the homepage.
+ */
+import { siteOwner, siteName } from "@/data/seo";
+
+interface Props {
+	siteUrl: string;
+	description: string;
+}
+
+const { siteUrl, description } = Astro.props;
+
+const jsonLd = {
+	"@context": "https://schema.org",
+	"@type": "WebSite",
+	name: siteName,
+	url: siteUrl,
+	description,
+	inLanguage: [...siteOwner.languages],
+	author: {
+		"@type": "Person",
+		name: siteOwner.name,
+	},
+};
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />

--- a/src/components/seo/index.ts
+++ b/src/components/seo/index.ts
@@ -5,6 +5,9 @@ export type { Props as SEOProps, ArticleMeta } from "./SEO.astro";
 // JSON-LD components
 export { default as PersonJsonLd } from "./PersonJsonLd.astro";
 export { default as ArticleJsonLd } from "./ArticleJsonLd.astro";
+export { default as WebSiteJsonLd } from "./WebSiteJsonLd.astro";
+export { default as BreadcrumbJsonLd } from "./BreadcrumbJsonLd.astro";
+export { default as HomePageJsonLd } from "./HomePageJsonLd.astro";
 
 // Meta components
 export { default as CanonicalMeta } from "./CanonicalMeta.astro";

--- a/src/data/seo.ts
+++ b/src/data/seo.ts
@@ -3,6 +3,7 @@ import { socials } from "./socials";
 /** Site owner information for SEO and JSON-LD */
 export const siteOwner = {
 	name: "Luis Urrutia",
+	email: "hello@urrutia.me",
 	address: {
 		locality: "Santiago",
 		country: "CL",
@@ -10,11 +11,23 @@ export const siteOwner = {
 	languages: ["en", "es"],
 } as const;
 
+/** Current employer for Person schema */
+export const employer = {
+	name: "OpenZeppelin",
+	url: "https://www.openzeppelin.com/",
+} as const;
+
+/** Site name for branding */
+export const siteName = "Luis Urrutia";
+
 /** Twitter/X handle for meta tags */
 export const twitterHandle = "@luisurrutia_dev";
 
 /** Default OG image path (relative to site root) */
 export const defaultOgImage = "/og-image.png";
+
+/** Profile image path for Person schema (relative to site root) */
+export const profileImage = "/images/profile.jpg";
 
 /** Extract URLs from socials for JSON-LD sameAs property */
 export const socialUrls = Object.values(socials).map((social) =>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -3,7 +3,7 @@ export const ui = {
 		// Meta
 		"meta.title": "Luis Urrutia | Senior Software Engineer",
 		"meta.description":
-			"Senior Software Engineer with 12+ years of experience building scalable web applications and leading development teams.",
+			"Senior Software Engineer with 12+ years of experience building and operating large-scale production systems, focused on system design, reliability, and measurable business impact.",
 		"meta.jobTitle": "Senior Software Engineer",
 		"meta.ogImageAlt": "Luis Urrutia - Senior Software Engineer",
 
@@ -39,9 +39,9 @@ export const ui = {
 
 		// Blog
 		"blog.title": "Latest posts",
-		"blog.pageTitle": "Blog",
+		"blog.pageTitle": "Luis Urrutia | Engineering Notes",
 		"blog.pageDescription":
-			"Thoughts on software engineering, web development, and technology.",
+			"Engineering notes by Luis Urrutia on system design, reliability, and building production software at scale.",
 		"blog.empty": "No posts available",
 		"blog.viewMore": "View More",
 		"blog.allPosts": "All Posts",
@@ -93,7 +93,7 @@ export const ui = {
 		// Meta
 		"meta.title": "Luis Urrutia | Ingeniero de Software Senior",
 		"meta.description":
-			"Ingeniero de Software Senior con más de 12 años de experiencia construyendo aplicaciones web escalables y liderando equipos de desarrollo.",
+			"Ingeniero de Software Senior con más de 12 años de experiencia construyendo y operando sistemas de producción a gran escala, enfocado en diseño de sistemas, confiabilidad e impacto medible en el negocio.",
 		"meta.jobTitle": "Ingeniero de Software Senior",
 		"meta.ogImageAlt": "Luis Urrutia - Ingeniero de Software Senior",
 
@@ -130,9 +130,9 @@ export const ui = {
 
 		// Blog
 		"blog.title": "Últimas publicaciones",
-		"blog.pageTitle": "Blog",
+		"blog.pageTitle": "Luis Urrutia | Engineering Notes",
 		"blog.pageDescription":
-			"Reflexiones sobre ingeniería de software, desarrollo web y tecnología.",
+			"Notas de ingeniería de Luis Urrutia sobre diseño de sistemas, confiabilidad y construcción de software de producción a escala.",
 		"blog.empty": "No hay publicaciones disponibles",
 		"blog.viewMore": "Ver más",
 		"blog.allPosts": "Todas las publicaciones",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,6 +59,9 @@ const {
 			href="/favicons/favicon-180x180.png"
 		/>
 
+		<!-- Sitemap -->
+		<link rel="sitemap" href="/sitemap-index.xml" />
+
 		<!-- Windows Tiles -->
 		<meta name="msapplication-TileColor" content="#FBFBF9" />
 		<meta name="msapplication-config" content="/browserconfig.xml" />

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+
+const getRobotsTxt = (sitemapURL: URL) => `User-agent: *
+Allow: /
+
+Sitemap: ${sitemapURL.href}
+`;
+
+export const GET: APIRoute = ({ site }) => {
+	const sitemapURL = new URL("sitemap-index.xml", site);
+	return new Response(getRobotsTxt(sitemapURL));
+};

--- a/src/views/BlogPage.astro
+++ b/src/views/BlogPage.astro
@@ -6,6 +6,7 @@ import Container from "@/components/Container.astro";
 import Card from "@/components/Card.astro";
 import BlogEntry from "@/components/BlogEntry.astro";
 import Pagination from "@/components/Pagination.astro";
+import { BreadcrumbJsonLd } from "@/components/seo";
 import { getLocalizedPath, getSlugWithoutLocale } from "@/i18n";
 
 interface Props {
@@ -16,6 +17,15 @@ interface Props {
 
 const { posts, currentPage, totalPages } = Astro.props;
 const { t, lang } = Astro.locals;
+
+// Use Astro.site from config, fallback to request origin in dev
+const siteUrl = (Astro.site ?? Astro.url.origin).toString().replace(/\/$/, "");
+
+// Breadcrumb items for blog listing page
+const breadcrumbItems = [
+	{ name: "Home", url: `${siteUrl}${getLocalizedPath("/", lang)}` },
+	{ name: "Blog", url: `${siteUrl}${getLocalizedPath("/blog", lang)}` },
+];
 
 // Helper to get the post URL
 function getPostUrl(id: string): string {
@@ -28,6 +38,7 @@ const baseUrl = getLocalizedPath("/blog", lang);
 ---
 
 <Layout title={t("blog.pageTitle")} description={t("blog.pageDescription")}>
+	<BreadcrumbJsonLd slot="head" items={breadcrumbItems} />
 	<Navbar />
 	<Container as="main" class="flex flex-col gap-8" transition:animate="slide">
 		<Card style="view-transition-name: post-card">

--- a/src/views/BlogPostPage.astro
+++ b/src/views/BlogPostPage.astro
@@ -6,6 +6,7 @@ import Navbar from "@/components/Navbar.astro";
 import Container from "@/components/Container.astro";
 import Card from "@/components/Card.astro";
 import Pill from "@/components/Pill.astro";
+import { ArticleJsonLd, BreadcrumbJsonLd } from "@/components/seo";
 import {
 	getAlternateLocale,
 	getLocalizedPath,
@@ -57,6 +58,17 @@ const alternateUrl = translatedPost
 const slug = getSlugWithoutLocale(post.id);
 const titleTransitionName = `post-title-${slug}`;
 const pillTransitionName = `post-pill-${slug}`;
+
+// Use Astro.site from config, fallback to request origin in dev
+const siteUrl = (Astro.site ?? Astro.url.origin).toString().replace(/\/$/, "");
+const postUrl = `${siteUrl}${getLocalizedPath(`/blog/${slug}`, lang)}`;
+
+// Breadcrumb items for blog post page
+const breadcrumbItems = [
+	{ name: "Home", url: `${siteUrl}${getLocalizedPath("/", lang)}` },
+	{ name: "Blog", url: `${siteUrl}${getLocalizedPath("/blog", lang)}` },
+	{ name: post.data.title, url: postUrl },
+];
 ---
 
 <Layout
@@ -69,6 +81,16 @@ const pillTransitionName = `post-pill-${slug}`;
 		tags: post.data.tags,
 	}}
 >
+	<BreadcrumbJsonLd slot="head" items={breadcrumbItems} />
+	<ArticleJsonLd
+		slot="head"
+		title={post.data.title}
+		description={post.data.description}
+		url={postUrl}
+		publishedTime={post.data.date.toISOString()}
+		modifiedTime={post.data.updatedDate?.toISOString()}
+		tags={post.data.tags}
+	/>
 	<Navbar />
 	<Container as="main" class="flex flex-col gap-8" transition:animate="slide">
 		<Card

--- a/src/views/HomePage.astro
+++ b/src/views/HomePage.astro
@@ -2,7 +2,7 @@
 import { getCollection } from "astro:content";
 import Layout from "@/layouts/Layout.astro";
 import Navbar from "@/components/Navbar.astro";
-import { PersonJsonLd } from "@/components/seo";
+import { HomePageJsonLd } from "@/components/seo";
 import { socials } from "@/data/socials";
 import { technologies } from "@/data/technologies";
 import { testimonials } from "@/data/testimonials";
@@ -41,7 +41,7 @@ const posts = allPosts
 ---
 
 <Layout ogImageAlt={t("meta.ogImageAlt")}>
-	<PersonJsonLd
+	<HomePageJsonLd
 		slot="head"
 		siteUrl={siteUrl}
 		jobTitle={t("meta.jobTitle")}


### PR DESCRIPTION
## Description

Comprehensive SEO improvements including structured data schemas, improved meta tags, and better search engine discoverability.

### Changes:
- **Schema Markup**: Add JSON-LD structured data with graph pattern combining WebSite, ProfilePage, and Person schemas on homepage
- **Breadcrumbs**: Add BreadcrumbList schema for blog pages navigation
- **Meta Tags**: Add og:site_name, sitemap link in head, and improved descriptions
- **robots.txt**: Dynamic generation with sitemap reference using Astro API route
- **Alt Text**: Add descriptive alt attributes to tech icons for image search visibility
- **SEO Copy**: Updated homepage and blog meta titles/descriptions

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

## Related Issues

N/A