### PR TITLE
feat(blog): add OG images, Giscus comments, and fix language switcher

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,11 +11,7 @@ export default defineConfig({
 
 	markdown: {
 		shikiConfig: {
-			themes: {
-				light: "catppuccin-mocha",
-				dark: "material-theme-ocean",
-			},
-			defaultColor: "light",
+			theme: "material-theme-ocean",
 		},
 	},
 

--- a/src/components/Giscus.astro
+++ b/src/components/Giscus.astro
@@ -1,0 +1,90 @@
+---
+/**
+ * Giscus - GitHub Discussions-based comments component.
+ *
+ * Features:
+ * - Syncs theme with site's light/dark mode
+ * - Supports i18n (en/es)
+ * - Lazy loads for performance
+ */
+import type { Locale } from "@/i18n";
+
+interface Props {
+	/** Current page locale */
+	lang?: Locale;
+}
+
+const { lang = "en" } = Astro.props;
+---
+
+<div class="giscus-wrapper border-border mt-8 border-t pt-8">
+	<div class="giscus"></div>
+</div>
+
+<script is:inline data-lang={lang}>
+	function loadGiscus() {
+		const wrapper = document.querySelector(".giscus-wrapper");
+		if (!wrapper || wrapper.dataset.loaded) return;
+
+		const lang = document.currentScript?.dataset.lang || "en";
+		const theme =
+			document.documentElement.dataset.theme === "dark"
+				? "transparent_dark"
+				: "light";
+
+		const script = document.createElement("script");
+		script.src = "https://giscus.app/client.js";
+		script.dataset.repo = "LuisUrrutia/website";
+		script.dataset.repoId = "R_kgDOQnDWeA";
+		script.dataset.category = "General";
+		script.dataset.categoryId = "DIC_kwDOQnDWeM4C1x7v";
+		script.dataset.mapping = "og:title";
+		script.dataset.strict = "0";
+		script.dataset.reactionsEnabled = "1";
+		script.dataset.emitMetadata = "0";
+		script.dataset.inputPosition = "top";
+		script.dataset.theme = theme;
+		script.dataset.lang = lang;
+		script.dataset.loading = "lazy";
+		script.crossOrigin = "anonymous";
+		script.async = true;
+
+		wrapper.appendChild(script);
+		wrapper.dataset.loaded = "true";
+	}
+
+	function updateGiscusTheme() {
+		const iframe = document.querySelector("iframe.giscus-frame");
+		if (!iframe) return;
+
+		const theme =
+			document.documentElement.dataset.theme === "dark"
+				? "transparent_dark"
+				: "light";
+
+		iframe.contentWindow?.postMessage(
+			{ giscus: { setConfig: { theme } } },
+			"https://giscus.app",
+		);
+	}
+
+	// Load on initial page load
+	loadGiscus();
+
+	// Reload after Astro page transitions
+	document.addEventListener("astro:after-swap", loadGiscus);
+
+	// Listen for theme changes
+	const observer = new MutationObserver((mutations) => {
+		for (const mutation of mutations) {
+			if (mutation.attributeName === "data-theme") {
+				updateGiscusTheme();
+			}
+		}
+	});
+
+	observer.observe(document.documentElement, {
+		attributes: true,
+		attributeFilter: ["data-theme"],
+	});
+</script>

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -5,27 +5,23 @@
  * Automatically detects current locale from Astro.locals and provides
  * a dropdown to switch between available languages.
  *
+ * Uses hreflang link tags from the document head as the source of truth
+ * for alternate language URLs. This ensures consistency with SEO meta tags
+ * and works correctly for pages with different slugs per locale (e.g., blog posts).
+ *
  * @example
  * ```astro
  * <LanguageSwitcher />
  * ```
  */
-import { locales, localeNames, getLocalizedPath } from "@/i18n";
+import { locales, localeNames } from "@/i18n";
 
 interface Props {
 	class?: string;
 }
 
 const { class: className } = Astro.props;
-const { lang, pathWithoutLocale, t } = Astro.locals;
-
-// Pre-compute paths for each locale
-const localePaths = Object.fromEntries(
-	locales.map((locale) => [
-		locale,
-		getLocalizedPath(pathWithoutLocale, locale),
-	]),
-);
+const { lang, t } = Astro.locals;
 ---
 
 <div
@@ -38,7 +34,6 @@ const localePaths = Object.fromEntries(
 	<select
 		id="language-select"
 		class="bg-card text-foreground hover:bg-card/80 focus:ring-accent cursor-pointer appearance-none rounded px-2 py-1 pr-7 text-sm transition-colors focus:ring-2 focus:outline-none"
-		data-locale-paths={JSON.stringify(localePaths)}
 	>
 		{
 			locales.map((locale) => (
@@ -63,6 +58,24 @@ const localePaths = Object.fromEntries(
 </div>
 
 <script>
+	/**
+	 * Gets alternate language URLs from hreflang link tags in the document head.
+	 * These are the canonical source of truth for language-specific URLs.
+	 */
+	function getHreflangUrls(): Record<string, string> {
+		const urls: Record<string, string> = {};
+		document
+			.querySelectorAll<HTMLLinkElement>('link[rel="alternate"][hreflang]')
+			.forEach((link) => {
+				const hreflang = link.getAttribute("hreflang");
+				// Skip x-default as it's not a specific locale
+				if (hreflang && hreflang !== "x-default") {
+					urls[hreflang] = link.href;
+				}
+			});
+		return urls;
+	}
+
 	function initLanguageSwitcher(): void {
 		document
 			.querySelectorAll<HTMLSelectElement>("#language-select")
@@ -72,10 +85,10 @@ const localePaths = Object.fromEntries(
 
 				select.addEventListener("change", () => {
 					const locale = select.value;
-					const paths = JSON.parse(select.dataset.localePaths || "{}");
-					const path = paths[locale];
-					if (path) {
-						window.location.href = path;
+					const urls = getHreflangUrls();
+					const url = urls[locale];
+					if (url) {
+						window.location.href = url;
 					}
 				});
 			});

--- a/src/components/seo/CanonicalMeta.astro
+++ b/src/components/seo/CanonicalMeta.astro
@@ -6,6 +6,9 @@
  * internationalized pages to help search engines understand
  * language/region variants.
  *
+ * For pages with content that has different slugs per locale (e.g., blog posts),
+ * pass the `alternateUrls` prop to override the default URL computation.
+ *
  * @see https://developers.google.com/search/docs/specialty/international/localized-versions
  */
 import { locales, getLocalizedPath, type Locale } from "@/i18n";
@@ -17,26 +20,33 @@ export interface Props {
 	pathWithoutLocale: string;
 	/** Current locale */
 	locale: Locale;
+	/** Custom alternate URLs per locale (for content with different slugs) */
+	alternateUrls?: Partial<Record<Locale, string>>;
 }
 
-const { siteUrl, pathWithoutLocale, locale } = Astro.props;
+const { siteUrl, pathWithoutLocale, locale, alternateUrls } = Astro.props;
 
-const canonicalPath = getLocalizedPath(pathWithoutLocale, locale);
-const canonicalUrl = `${siteUrl}${canonicalPath}`;
+// Compute URL for a locale, using custom alternateUrls if provided
+const getUrlForLocale = (loc: Locale): string => {
+	if (alternateUrls?.[loc]) {
+		const path = alternateUrls[loc];
+		return path.startsWith("http") ? path : `${siteUrl}${path}`;
+	}
+	return `${siteUrl}${getLocalizedPath(pathWithoutLocale, loc)}`;
+};
+
+const canonicalUrl = getUrlForLocale(locale);
+
+// x-default should point to the default (non-prefixed) path
+const xDefaultUrl = alternateUrls?.en
+	? `${siteUrl}${alternateUrls.en}`
+	: `${siteUrl}${pathWithoutLocale}`;
 ---
 
 <link rel="canonical" href={canonicalUrl} />
 {
 	locales.map((loc) => (
-		<link
-			rel="alternate"
-			hreflang={loc}
-			href={`${siteUrl}${getLocalizedPath(pathWithoutLocale, loc)}`}
-		/>
+		<link rel="alternate" hreflang={loc} href={getUrlForLocale(loc)} />
 	))
 }
-<link
-	rel="alternate"
-	hreflang="x-default"
-	href={`${siteUrl}${pathWithoutLocale}`}
-/>
+<link rel="alternate" hreflang="x-default" href={xDefaultUrl} />

--- a/src/components/seo/SEO.astro
+++ b/src/components/seo/SEO.astro
@@ -26,6 +26,8 @@ import { defaultOgImage } from "@/data/seo";
 
 export type { ArticleMeta };
 
+import type { Locale } from "@/i18n";
+
 export interface Props {
 	/** Page title */
 	title: string;
@@ -41,6 +43,8 @@ export interface Props {
 	article?: ArticleMeta;
 	/** Prevent search engines from indexing this page */
 	noindex?: boolean;
+	/** Custom alternate URLs per locale (for content with different slugs) */
+	alternateUrls?: Partial<Record<Locale, string>>;
 }
 
 const { lang, pathWithoutLocale } = Astro.locals;
@@ -53,6 +57,7 @@ const {
 	ogType = "website",
 	article,
 	noindex = false,
+	alternateUrls,
 } = Astro.props;
 
 // Use Astro.site from config, fallback to request origin in dev
@@ -84,6 +89,7 @@ const robotsContent = noindex ? "noindex, nofollow" : "index, follow";
 	siteUrl={siteUrl}
 	pathWithoutLocale={pathWithoutLocale}
 	locale={lang}
+	alternateUrls={alternateUrls}
 />
 
 <!-- Open Graph -->

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -95,7 +95,7 @@
 	--oklch-foreground: 0.82 0.02 269.76;
 	--oklch-title: 96% 0 0;
 	--oklch-subtitle: 0.72 0.04 275.55;
-	--oklch-card: 0.22 0.05 269.24;
+	--oklch-card: 0.21 0.04 269.51;
 	--oklch-card-foreground: 85% 0.01 270;
 	--oklch-available: 45% 0.12 150;
 	--oklch-available-foreground: 90% 0.05 150;
@@ -114,10 +114,4 @@
 	/* Code */
 	--oklch-code-foreground: 0.78 0.15 3.85;
 	--oklch-code-background: 0.29 0.06 327.01;
-}
-
-[data-theme="dark"] .astro-code,
-[data-theme="dark"] .astro-code span {
-	background-color: var(--shiki-dark-bg) !important;
-	color: var(--shiki-dark) !important;
 }

--- a/src/views/BlogPostPage.astro
+++ b/src/views/BlogPostPage.astro
@@ -15,6 +15,7 @@ import {
 	localeNames,
 } from "@/i18n";
 import { calculateReadingTime, formatReadingTime } from "@/lib/formatters";
+import Giscus from "@/components/Giscus.astro";
 
 interface Props {
 	post: CollectionEntry<"blog">;
@@ -45,6 +46,9 @@ const formattedUpdatedDate = post.data.updatedDate
 	? post.data.updatedDate.toLocaleDateString(intlLocales[lang], dateFormat)
 	: null;
 
+// Generate transition names from post slug
+const slug = getSlugWithoutLocale(post.id);
+
 // Get the alternate language URL
 const alternateLang = getAlternateLocale(lang);
 const alternateUrl = translatedPost
@@ -54,8 +58,14 @@ const alternateUrl = translatedPost
 		)
 	: null;
 
-// Generate transition names from post slug
-const slug = getSlugWithoutLocale(post.id);
+// Build alternate URLs for hreflang tags (used by SEO and language switcher)
+const currentPostUrl = getLocalizedPath(`/blog/${slug}`, lang);
+const alternateUrls = {
+	[lang]: currentPostUrl,
+	[alternateLang]:
+		alternateUrl ?? getLocalizedPath(`/blog/${slug}`, alternateLang),
+};
+
 const titleTransitionName = `post-title-${slug}`;
 const pillTransitionName = `post-pill-${slug}`;
 
@@ -85,6 +95,7 @@ const breadcrumbItems = [
 	description={post.data.description}
 	ogImage={ogImage}
 	ogType="article"
+	alternateUrls={alternateUrls}
 	article={{
 		publishedTime: post.data.date.toISOString(),
 		modifiedTime: post.data.updatedDate?.toISOString(),
@@ -156,6 +167,8 @@ const breadcrumbItems = [
 			<div class="blog-content">
 				<Content />
 			</div>
+
+			<Giscus lang={lang} />
 		</Card>
 	</Container>
 </Layout>


### PR DESCRIPTION
## Description

This PR enhances the blog with several improvements:

- **OG Image Generation**: Automatic 1200x630 PNG images for each blog post using `astro-og-canvas`
- **Giscus Comments**: GitHub Discussions-based commenting system with theme sync and i18n support
- **Language Switcher Fix**: Now correctly navigates to translated post slugs by reading hreflang links from DOM
- **SEO Improvements**: Added `alternateUrls` prop to SEO components for correct hreflang tags on translated content
- **Theme Refinements**: Simplified Shiki config, tweaked dark mode card color

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

## Related Issues

<!-- No related issues -->