### PR TITLE
Mark portfolio as open to work

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
         with:

--- a/src/views/HomePage.astro
+++ b/src/views/HomePage.astro
@@ -54,7 +54,7 @@ const posts = allPosts
 		class="flex flex-col gap-8"
 		transition:animate="fade"
 	>
-		<HeroSection socials={socials} />
+		<HeroSection socials={socials} workStatus="open" />
 		<StackSection technologies={technologies} />
 		{
 			posts.length > 0 && (


### PR DESCRIPTION
## Summary
- set the homepage hero status badge to `Open to work`
- keep the existing localized status copy and badge styles intact by using the existing `workStatus` prop

## Validation
- bun run lint
- bun run build