### PR TITLE
chore(deps): bump semantic-release, gate PRs on astro check

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Type check
+        run: bun run check
+
       - name: Format check
         run: bun run fmt
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ bun install          # Install dependencies
 bun run dev          # Dev server at localhost:4321
 bun run build        # Production build to dist/
 bun run lint         # OxLint with type-aware rules
+bun run check        # Type check with astro check
 bun run test         # Vitest test suite
 bun run fmt:fix      # Auto-fix formatting
 bun run fmt          # Check formatting (CI)

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@
 
 ### CI/CD
 
-| Workflow   | Description                                       |
-| ---------- | ------------------------------------------------- |
-| Verify     | Lint, format check, tests, and build on PRs       |
-| Release    | Semantic-release with Cloudflare Pages deployment |
-| CodeQL     | Security vulnerability scanning                   |
-| Lighthouse | Performance and accessibility audits (>= 90%)     |
-| Commitlint | Validates conventional commit format              |
-| Dependabot | Weekly automated dependency updates               |
+| Workflow   | Description                                             |
+| ---------- | ------------------------------------------------------- |
+| Verify     | Lint, type check, format check, tests, and build on PRs |
+| Release    | Semantic-release with Cloudflare Pages deployment       |
+| CodeQL     | Security vulnerability scanning                         |
+| Lighthouse | Performance and accessibility audits (>= 90%)           |
+| Commitlint | Validates conventional commit format                    |
+| Dependabot | Weekly automated dependency updates                     |
 
 ## Getting Started
 
@@ -101,16 +101,17 @@ The site will be available at `http://localhost:4321` with hot module replacemen
 
 ### Commands
 
-| Command                 | Description                                           |
-| ----------------------- | ----------------------------------------------------- |
-| `bun run dev`           | Start development server at `localhost:4321` with HMR |
-| `bun run build`         | Build optimized production site to `dist/`            |
-| `bun run preview`       | Preview the production build locally                  |
-| `bun run build:preview` | Build and preview in one command                      |
-| `bun run lint`          | Run OxLint with type-aware rules                      |
-| `bun run fmt`           | Check code formatting with Prettier                   |
-| `bun run fmt:fix`       | Auto-fix formatting issues                            |
-| `bun run test`          | Run the Vitest suite                                  |
+| Command                 | Description                                            |
+| ----------------------- | ------------------------------------------------------ |
+| `bun run dev`           | Start development server at `localhost:4321` with HMR  |
+| `bun run build`         | Build optimized production site to `dist/`             |
+| `bun run preview`       | Preview the production build locally                   |
+| `bun run build:preview` | Build and preview in one command                       |
+| `bun run lint`          | Run OxLint with type-aware rules                       |
+| `bun run check`         | Type check `.astro` and `.ts` files with `astro check` |
+| `bun run fmt`           | Check code formatting with Prettier                    |
+| `bun run fmt:fix`       | Auto-fix formatting issues                             |
+| `bun run test`          | Run the Vitest suite                                   |
 
 ### Testing with Docker
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "astro": "astro",
     "build": "astro build",
     "build:preview": "rm -rf dist; astro build && astro preview",
+    "check": "astro check",
     "dev": "astro dev",
     "fmt": "prettier . --check",
     "fmt:fix": "prettier . --write",


### PR DESCRIPTION
## Description

Splits Dependabot PR #107 by cooldown and lands only the part that clears it: the three semantic-release packages. Also wires `astro check` into `verify.yml`, because it was the only check that caught the TypeScript 7 breakage hiding in that same group.

**Landed:**

- `semantic-release` 25.0.3 → 25.0.9
- `@semantic-release/github` 12.0.6 → 12.0.9
- `@semantic-release/release-notes-generator` 14.1.0 → 14.1.1

**Held back from the group:**

- `astro` 7.2.0 — published 2026-08-06T10:48Z, so 6 days old against the 7-day `semver-major-days` cooldown. Clears 2026-08-13.
- `typescript` 7.0.2 — clears cooldown at 35 days, but `@astrojs/check@0.9.10` (the latest release) peers on `typescript ^5.0.0 || ^6.0.0`. Under TS 7, `astro check` dies with `Cannot read properties of undefined (reading 'fileExists')` at `@astrojs/language-server/dist/check.js:162`. Bisected: TS 6.0.3 gives 102 files / 0 errors, TS 7.0.2 crashes. Now ignored for majors in `dependabot.yml` with the reason inline.

`verify.yml` ran lint, format, tests, and build — never `astro check` — so it would have merged that bump green. The new `Type check` step closes the gap.

Dependabot PR #99 (`actions/cache` 5.0.5 → 6.1.0) was closed separately as obsolete: 827d245 removed `actions/cache` from every workflow. `oven-sh/setup-bun` only caches the Bun binary, not `~/.bun/install/cache`, but install time is 1–3s with the cache (runs 31102820949, 30008303521) and 1–3s without it (runs 31374182274, 31311656100), so the step was paying a `restore-keys` cache-poisoning surface on a `pull_request` workflow for nothing.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

Validation on this branch:

| Check | Result |
| --- | --- |
| `bun run lint` | exit 0 |
| `bun run check` | 102 files, 0 errors, 0 warnings, 1 hint (pre-existing TS6196) |
| `bun run fmt` | clean |
| `bun run test` | 5 files, 29 tests passed |
| `bun run build` | 9 pages, Complete |
| `bunx semantic-release --dry-run` | 16 plugins loaded, exit 0 |
| `actionlint` | clean |

Type-aware linting was separately confirmed to still fire rather than pass silently: a floating promise trips `typescript(no-floating-promises)`.

## Review guide

Start with `.github/workflows/verify.yml` and `.github/dependabot.yml`; both are three-line changes. `bun.lock` is generated. The `ignore` entry in `dependabot.yml` should come back out once `@astrojs/check` ships TypeScript 7 support.

## Related Issues

Supersedes part of #107, which will rebase to `astro` + `typescript` once this merges. Closes #99.

## AI assistance

Claude reviewed both open Dependabot PRs against the configured cooldown, bisected the TypeScript 7 failure against `@astrojs/check`, pulled the CI cache timings from the Actions API, and wrote these changes. Every command in the validation table was run on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Project verification now includes automated TypeScript and Astro type checking alongside existing quality checks.
  - Updated development tooling and security safeguards to improve reliability and maintenance.

- **Documentation**
  - Added instructions for running type checks locally.
  - Expanded guidance for blog components, content formatting, project structure, and key files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->